### PR TITLE
feat(add-caddy-config): Caddy Reverse Proxy Config

### DIFF
--- a/docs/docker/reverse-proxies.md
+++ b/docs/docker/reverse-proxies.md
@@ -64,3 +64,15 @@ server {
   }
 }
 ```
+
+## Caddy
+Make sure to use HTTPS for redirection to avoid mixed content errors. 
+
+Add this to your Caddyfile:
+```Caddyfile
+links.example.com {
+  reverse_proxy https://localhost:443 {
+    tls_insecure_skip_verify
+  }
+}
+```


### PR DESCRIPTION
Hey there,
I added a configuration example for caddy to the already existing examples. I know, caddy isn't that complex like the other two examples, but because caddy is becoming a popular option for a reverse proxy, I think it should be mentioned there.