### PR TITLE
Added needed ports for compose

### DIFF
--- a/docs/docker/setup.md
+++ b/docs/docker/setup.md
@@ -73,6 +73,9 @@ services:
       - LOG_LEVEL=info
       - PHP_MEMORY_LIMIT=512M
       - UPLOAD_MAX_FILESIZE=16M
+    ports:
+      - "80:80"
+      - "443:443"
     volumes:
       - linkstack:/htdocs
     restart: unless-stopped


### PR DESCRIPTION
The docker compose example had the ports missing why it wouldn't work if you use it with a reverse proxy outside of docker, for example.